### PR TITLE
[link] add "Kata Japan" (closes #3)

### DIFF
--- a/_includes/links-list.html
+++ b/_includes/links-list.html
@@ -3,5 +3,6 @@
   <li><a href="https://coderdojo.com/" target="_blank">CoderDojo</a></li>
   <li><a href="http://scratch.mit.edu" target="_blank">Scratch</a></li>
   <li><a href="http://coderdojo.jp/" target="_blank">CoderDojo Japan</a></li>
+  <li><a href="http://kata.coderdojo.com/wiki/KataJapan" target="_blank">Kata Japan</a></li>
   <li><a href="http://hackerspace-nagoya.squarespace.com/" target="_blank">Hacker Space Nagoya</a></li>
 </ul>


### PR DESCRIPTION
refs #3 

現時点でKata Japanのコンテンツが運営者向け情報のみとなっているため、学習リソースページにリストアップはしない。
